### PR TITLE
No compiler dependency runtime

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -41,7 +41,6 @@ requirements:
     - jinja2 >=2.7
     - setuptools >=6.0
     - py-cpuinfo >=0.1.6
-    - {{ compiler('cxx') }}
 
 test:
   imports:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,0 +1,8 @@
+ECHO "" >> "%PREFIX%"\.messages.txt
+ECHO "Please note that Brian2's conda package does not automatically install a " >> "%PREFIX%"\.messages.txt
+ECHO "C++ compiler. Such a compiler is necessary to benefit from C++ code " >> "%PREFIX%"\.messages.txt
+ECHO "generation and the resulting improved performance. " >> "%PREFIX%"\.messages.txt
+ECHO "See the 'Requirements for C++ code generation' section at " >> "%PREFIX%"\.messages.txt
+ECHO "     http:\\brian2.readthedocs.io\en\%PKG_VERSION%\introduction\install.html" >> "%PREFIX%"\.messages.txt
+ECHO "for details." >> "%PREFIX%"\.messages.txt
+

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,8 +1,8 @@
-ECHO "" >> "%PREFIX%"\.messages.txt
-ECHO "Please note that Brian2's conda package does not automatically install a " >> "%PREFIX%"\.messages.txt
-ECHO "C++ compiler. Such a compiler is necessary to benefit from C++ code " >> "%PREFIX%"\.messages.txt
-ECHO "generation and the resulting improved performance. " >> "%PREFIX%"\.messages.txt
-ECHO "See the 'Requirements for C++ code generation' section at " >> "%PREFIX%"\.messages.txt
-ECHO "     http:\\brian2.readthedocs.io\en\%PKG_VERSION%\introduction\install.html" >> "%PREFIX%"\.messages.txt
-ECHO "for details." >> "%PREFIX%"\.messages.txt
+ECHO. >> "%PREFIX%"\.messages.txt
+ECHO Please note that Brian2's conda package does not automatically install a >> "%PREFIX%"\.messages.txt
+ECHO C++ compiler. Such a compiler is necessary to benefit from C++ code >> "%PREFIX%"\.messages.txt
+ECHO generation and the resulting improved performance. >> "%PREFIX%"\.messages.txt
+ECHO See the 'Requirements for C++ code generation' section at >> "%PREFIX%"\.messages.txt
+ECHO      http://brian2.readthedocs.io/en/%PKG_VERSION%/introduction/install.html >> "%PREFIX%"\.messages.txt
+ECHO for details. >> "%PREFIX%"\.messages.txt
 

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "" >> "$PREFIX"/.messages.txt
+echo -n "Please note that Brian2's conda package does not automatically install a " >> "$PREFIX"/.messages.txt
+echo -n "C++ compiler. Such a compiler is necessary to benefit from C++ code " >> "$PREFIX"/.messages.txt
+echo "generation and the resulting improved performance. " >> "$PREFIX"/.messages.txt
+echo "See the 'Requirements for C++ code generation' section at " >> "$PREFIX"/.messages.txt
+echo "     http://brian2.readthedocs.io/en/$PKG_VERSION/introduction/install.html" >> "$PREFIX"/.messages.txt
+echo "for details." >> "$PREFIX"/.messages.txt
+


### PR DESCRIPTION
Remove the runtime dependency on a C++ compiler, since conda-forge does not yet use Anaconda's new compiler infrastructure (`{{ compiler('cxx') }}` translates into a `toolchain` dependency which only sets things up for building on the CI servers and is not meant as a runtime dependency).