### PR TITLE
Avoid runtime installation of VS on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - jinja2 >=2.7
     - setuptools >=21
     - py-cpuinfo  # [win]
-    - cxx-compiler  # [unix]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -41,7 +41,7 @@ requirements:
     - jinja2 >=2.7
     - setuptools >=21
     - py-cpuinfo  # [win]
-    - {{ compiler('cxx') }}  # [unix]
+    - {{ compiler('cxx') }}  # [not win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - jinja2 >=2.7
     - setuptools >=21
     - py-cpuinfo  # [win]
-    - {{ compiler('cxx') }}  # [not win]
+    - cxx-compiler  # [unix]
 
 test:
   imports:


### PR DESCRIPTION
Even though the `{compiler('cxx')}` *runtime* dependency is annotated with the `[unix]` selector, it still gets installed for Windows (where this dependency does not install anything, but only activates an existing installation and makes the conda environment unusable if there is none). With this PR, I'll try to see whether using `[not win]` instead of `[unix]` works.
